### PR TITLE
Add lite apple shop example

### DIFF
--- a/examples/lite-apple-shop/README.md
+++ b/examples/lite-apple-shop/README.md
@@ -1,0 +1,9 @@
+# Lite Apple Shop
+
+Small demo showing Core Kit Lite plugins working together.
+
+## Run
+
+On Windows run `start.bat` and open [http://localhost:8080/](http://localhost:8080/).
+
+On other systems start any static server in this folder.

--- a/examples/lite-apple-shop/game.json
+++ b/examples/lite-apple-shop/game.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": "1.0",
+  "game": { "title": "Lite Apple Shop", "seed": 7, "startScene": "village" },
+  "display": { "width": 960, "height": 540 },
+  "assets": [
+    { "key": "bg_village", "type": "image", "url": "assets/bg_village.png" },
+    { "key": "player", "type": "image", "url": "assets/player.png" },
+    { "key": "npc", "type": "image", "url": "assets/npc.png" },
+    { "key": "apple", "type": "image", "url": "assets/apple.png" }
+  ],
+  "characters": [
+    { "id": "hero", "name": "Tony", "sprite": "player", "money": 50, "energy": 100 }
+  ],
+  "inventory": { "shared": [], "byCharacter": { "hero": [] } },
+  "dialogues": [
+    {
+      "id": "merchant_intro",
+      "lines": [
+        {
+          "text": "Apples for sale! Want one for 10?",
+          "options": [
+            { "label": "Buy (10)",  "action": { "type": "trade", "op": "buy",  "item": "apple", "price": 10, "q": 1 } },
+            { "label": "Sell (10)", "action": { "type": "trade", "op": "sell", "item": "apple", "price": 10, "q": 1 } },
+            { "label": "Leave",     "action": { "type": "close_dialog" } }
+          ]
+        }
+      ]
+    }
+  ],
+  "shops": [
+    { "id": "fruit_stand", "items": [ { "id": "apple", "price": 10 } ] }
+  ],
+  "scenes": [
+    {
+      "id": "village",
+      "background": "bg_village",
+      "entities": [
+        { "type": "player", "id": "hero", "spawn": [120, 360], "sprite": "player" },
+        { "type": "npc", "id": "merchant", "spawn": [320, 340], "sprite": "npc", "dialog": "merchant_intro" }
+      ],
+      "shops": ["fruit_stand"]
+    }
+  ]
+}

--- a/examples/lite-apple-shop/index.html
+++ b/examples/lite-apple-shop/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lite Apple Shop</title>
+    <style>
+      body { margin: 0; background: #222; color: #fff; font-family: sans-serif; text-align: center; }
+      #game { width: 960px; height: 540px; margin: 2rem auto; position: relative; border: 1px solid #444; }
+    </style>
+  </head>
+  <body>
+    <h1>Lite Apple Shop Demo</h1>
+    <div id="game"></div>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <script src="../../dist/core-kit.umd.js"></script>
+    <script>
+      const core = PCore.createCore({ container: '#game', width: 960, height: 540, seed: 7 });
+      PCore.DialogueLite.init(core);
+      PCore.InventoryLite.init(core);
+      PCore.TradeLite.init(core);
+      PCore.CharactersLite.init(core);
+      PCore.LocationLite.init(core);
+      core.loadConfig('game.json').then(() => {
+        const money = core.registry.get('char.hero.money');
+        const energy = core.registry.get('char.hero.energy');
+        core.ui.hud.set({ money, energy });
+        core.bus.on('char:changed', (p) => {
+          if (p.id === 'hero') {
+            if (p.key === 'money') core.ui.hud.patch({ money: p.value });
+            if (p.key === 'energy') core.ui.hud.patch({ energy: p.value });
+          }
+        });
+        core.start();
+      });
+    </script>
+  </body>
+</html>

--- a/examples/lite-apple-shop/start.bat
+++ b/examples/lite-apple-shop/start.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+
+where http-server >nul 2>nul
+if %ERRORLEVEL%==0 (
+  echo Starting http-server on http://localhost:8080 ...
+  http-server -p 8080 .
+  goto :end
+)
+
+where python >nul 2>nul
+if %ERRORLEVEL%==0 (
+  echo Starting Python HTTP server on http://localhost:8080 ...
+  python -m http.server 8080
+  goto :end
+)
+
+echo.
+echo No local server found.
+echo Install one of:
+echo   npm i -g http-server
+echo OR
+echo   Install Python and rerun
+echo.
+:end
+endlocal


### PR DESCRIPTION
## Summary
- add "lite-apple-shop" example demonstrating Core Kit Lite plugins working together
- remove binary image assets so users can supply them separately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991aed3f90832b96ac19cef7417c6b